### PR TITLE
Correct typos in NetworkObservableProvider

### DIFF
--- a/rx-android-extensions/src/main/java/com/appunite/rx/android/NetworkObservableProviderImpl.java
+++ b/rx-android-extensions/src/main/java/com/appunite/rx/android/NetworkObservableProviderImpl.java
@@ -26,7 +26,6 @@ import android.telephony.TelephonyManager;
 
 import com.appunite.rx.ObservableExtensions;
 import com.appunite.rx.observables.NetworkObservableProvider;
-import com.appunite.rx.operators.MoreOperators;
 
 import javax.annotation.Nonnull;
 
@@ -86,17 +85,17 @@ public class NetworkObservableProviderImpl implements NetworkObservableProvider 
         } else if (type == ConnectivityManager.TYPE_MOBILE) {
             switch (subtype) {
                 case TelephonyManager.NETWORK_TYPE_1xRTT:
-                    return NetworkStatus.WEEK; // ~ 50-100 kbps
+                    return NetworkStatus.WEAK; // ~ 50-100 kbps
                 case TelephonyManager.NETWORK_TYPE_CDMA:
-                    return NetworkStatus.WEEK; // ~ 14-64 kbps
+                    return NetworkStatus.WEAK; // ~ 14-64 kbps
                 case TelephonyManager.NETWORK_TYPE_EDGE:
-                    return NetworkStatus.WEEK; // ~ 50-100 kbps
+                    return NetworkStatus.WEAK; // ~ 50-100 kbps
                 case TelephonyManager.NETWORK_TYPE_EVDO_0:
-                    return NetworkStatus.WEEK; // ~ 400-1000 kbps
+                    return NetworkStatus.WEAK; // ~ 400-1000 kbps
                 case TelephonyManager.NETWORK_TYPE_EVDO_A:
-                    return NetworkStatus.WEEK; // ~ 600-1400 kbps
+                    return NetworkStatus.WEAK; // ~ 600-1400 kbps
                 case TelephonyManager.NETWORK_TYPE_GPRS:
-                    return NetworkStatus.WEEK; // ~ 100 kbps
+                    return NetworkStatus.WEAK; // ~ 100 kbps
                 case TelephonyManager.NETWORK_TYPE_HSDPA:
                     return NetworkStatus.BEST; // ~ 2-14 Mbps
                 case TelephonyManager.NETWORK_TYPE_HSPA:

--- a/rx-extensions/src/main/java/com/appunite/rx/observables/NetworkObservableProvider.java
+++ b/rx-extensions/src/main/java/com/appunite/rx/observables/NetworkObservableProvider.java
@@ -22,9 +22,9 @@ import rx.Observable;
 
 public interface NetworkObservableProvider {
 
-    public static enum NetworkStatus {
+    enum NetworkStatus {
         NO_NETWORK(0),
-        WEEK(1),
+        WEAK(1),
         GOOD(2),
         BEST(3);
 
@@ -34,12 +34,12 @@ public interface NetworkObservableProvider {
             this.pos = pos;
         }
 
-        public boolean isNetowrk() {
+        public boolean isNetwork() {
             return pos > 0;
         }
 
-        public boolean weekOrBetter() {
-            return pos >= WEEK.pos;
+        public boolean weakOrBetter() {
+            return pos >= WEAK.pos;
         }
 
         public boolean goodOrBetter() {
@@ -52,5 +52,5 @@ public interface NetworkObservableProvider {
     }
 
     @Nonnull
-    public Observable<NetworkStatus> networkObservable();
+    Observable<NetworkStatus> networkObservable();
 }

--- a/rx-extensions/src/main/java/com/appunite/rx/operators/MoreOperators.java
+++ b/rx-extensions/src/main/java/com/appunite/rx/operators/MoreOperators.java
@@ -229,7 +229,7 @@ public class MoreOperators {
                                         .filter(new Func1<NetworkObservableProvider.NetworkStatus, Boolean>() {
                                             @Override
                                             public Boolean call(NetworkObservableProvider.NetworkStatus networkStatus) {
-                                                return networkStatus.isNetowrk();
+                                                return networkStatus.isNetwork();
                                             }
                                         });
                                 final Observable<Long> timeout = Observable.timer(integer, TimeUnit.SECONDS, scheduler);


### PR DESCRIPTION
I also suggest to change `isNetwork()` to `isNetworkAvailable()` or shorter `isConnected()` in `NetworkStatus`. `isNetwork()` may be ambiguous.
