### PR TITLE
New CacheSubject that can propagate null value

### DIFF
--- a/rx-extensions/src/main/java/com/appunite/rx/subjects/CacheSubject.java
+++ b/rx-extensions/src/main/java/com/appunite/rx/subjects/CacheSubject.java
@@ -41,7 +41,12 @@ public class CacheSubject<T> extends Subject<T, T> {
 
     @Nonnull
     public static <T> CacheSubject<T> create(@Nonnull CacheCreator<T> cacheCreator) {
-        return new CacheSubject<>(cacheCreator, new DelegateOnSubscribe<T>());
+        return create(cacheCreator, true);
+    }
+
+    @Nonnull
+    public static <T> CacheSubject<T> create(@Nonnull CacheCreator<T> cacheCreator, final boolean skipFirstNull) {
+        return new CacheSubject<>(cacheCreator, new DelegateOnSubscribe<T>(), skipFirstNull);
     }
 
     @Nonnull
@@ -67,13 +72,15 @@ public class CacheSubject<T> extends Subject<T, T> {
         };
     }
 
-    private CacheSubject(@Nonnull final CacheCreator<T> cacheCreator, DelegateOnSubscribe<T> delegateOnSubscribe) {
+    private CacheSubject(@Nonnull final CacheCreator<T> cacheCreator,
+                         @Nonnull DelegateOnSubscribe<T> delegateOnSubscribe,
+                         final boolean skipFirstNull) {
         super(delegateOnSubscribe);
         delegateOnSubscribe.setDelegate(new OnSubscribe<T>() {
             @Override
             public void call(final Subscriber<? super T> child) {
                 final T t = cacheCreator.readFromCache();
-                if (t != null) {
+                if (!skipFirstNull || t != null) {
                     child.onNext(t);
                 }
                 add(child);

--- a/rx-extensions/src/test/java/com/appunite/rx/subjects/CacheSubjectTest.java
+++ b/rx-extensions/src/test/java/com/appunite/rx/subjects/CacheSubjectTest.java
@@ -24,6 +24,7 @@ import org.mockito.MockitoAnnotations;
 import java.io.IOException;
 
 import rx.Observer;
+import rx.observers.TestSubscriber;
 
 import static com.google.common.truth.Truth.assert_;
 import static org.mockito.Matchers.anyString;
@@ -47,6 +48,26 @@ public class CacheSubjectTest {
         subject.subscribe(observer);
 
         verify(observer, never()).onNext(anyString());
+    }
+
+    @Test
+    public void testSubscribeToEmptyCacheAndSkipEmpty_doNotCallOnNext() throws Exception {
+        final TestSubscriber<String> subscriber = new TestSubscriber<>();
+        final CacheSubject<String> subject = CacheSubject.create(new CacheSubject.InMemoryCache<String>(null), true);
+
+        subject.subscribe(subscriber);
+
+        assert_().that(subscriber.getOnNextEvents()).isEmpty();
+    }
+
+    @Test
+    public void testSubscribeToEmptyCacheAndDoNotSkipEmpty_callOnNext() throws Exception {
+        final TestSubscriber<String> subscriber = new TestSubscriber<>();
+        final CacheSubject<String> subject = CacheSubject.create(new CacheSubject.InMemoryCache<String>(null), false);
+
+        subject.subscribe(subscriber);
+
+        assert_().that(subscriber.getOnNextEvents()).containsExactly((String) null);
     }
 
     @Test


### PR DESCRIPTION
Now CacheSubject can also return value even if it's null. This can be useful if "null" value can be pushed to CacheSubject from some observable
