### PR TITLE
Fixed unsubscribe issue in OperatorMergeNextToken

### DIFF
--- a/rx-extensions/src/main/java/com/appunite/rx/operators/OperatorMergeNextToken.java
+++ b/rx-extensions/src/main/java/com/appunite/rx/operators/OperatorMergeNextToken.java
@@ -53,7 +53,7 @@ public class OperatorMergeNextToken<T, K> implements Observable.Operator<T, K> {
 
     @Override
     public Subscriber<? super K> call(final Subscriber<? super T> child) {
-        return new Subscriber<K>() {
+        return new Subscriber<K>(child) {
             private final ReentrantLock lock = new ReentrantLock();
             private T previous = initialValue;
             private boolean skip = false;


### PR DESCRIPTION
There were an important issue where OperatorMergeNextToken would not unsubscribed its children's
