### PR TITLE
Added onSubscribe and onUnsubscribe methods to Log Transformer

### DIFF
--- a/rx-android-extensions/src/main/java/com/appunite/rx/android/util/LogTransformer.java
+++ b/rx-android-extensions/src/main/java/com/appunite/rx/android/util/LogTransformer.java
@@ -36,17 +36,13 @@ public class LogTransformer {
             @Override
             public void logSubscribe(@NonNull String tag, @Nonnull String observableTag) {
                 final java.util.logging.Logger logger = java.util.logging.Logger.getLogger(tag);
-                if (logger.isLoggable(Level.INFO)) {
-                    logger.log(Level.INFO, observableTag + " -> onSubscribe");
-                }
+                logger.log(Level.INFO, observableTag + " -> onSubscribe");
             }
 
             @Override
             public void logUnsubscribe(@NonNull String tag, @Nonnull String observableTag) {
                 final java.util.logging.Logger logger = java.util.logging.Logger.getLogger(tag);
-                if (logger.isLoggable(Level.INFO)) {
-                    logger.log(Level.INFO, observableTag + " -> onUnsubscribe");
-                }
+                logger.log(Level.INFO, observableTag + " -> onUnsubscribe");
             }
 
             @Override
@@ -73,45 +69,49 @@ public class LogTransformer {
 
         /**
          * Log onSubscribe
-         * @param tag Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.
+         *
+         * @param tag           Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.
          * @param observableTag Used to identify transformed observable.
          */
         void logSubscribe(@NonNull String tag, @Nonnull String observableTag);
 
         /**
          * Log onUnsubscribe
-         * @param tag Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.
+         *
+         * @param tag           Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.
          * @param observableTag Used to identify transformed observable.
          */
         void logUnsubscribe(@NonNull String tag, @Nonnull String observableTag);
 
         /**
          * Log onNext event.
-         * @param tag Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.
+         *
+         * @param tag           Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.
          * @param observableTag Used to identify transformed observable.
-         * @param object Object passed to onNext method.
+         * @param object        Object passed to onNext method.
          */
         void logNext(@NonNull String tag, @Nonnull String observableTag, @Nullable Object object);
 
         /**
          * Log onError event.
-         * @param tag Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.
+         *
+         * @param tag           Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.
          * @param observableTag Used to identify transformed observable.
-         * @param throwable Throwable passed to onError method.
+         * @param throwable     Throwable passed to onError method.
          */
         void logError(@NonNull String tag, @Nonnull String observableTag, @Nullable Throwable throwable);
 
         /**
          * Log onCompleted event.
-         * @param tag Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.
+         *
+         * @param tag           Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.
          * @param observableTag Used to identify transformed observable.
          */
         void logCompleted(@NonNull String tag, @Nonnull String observableTag);
     }
 
     /**
-     *
-     * @param logTag Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.
+     * @param logTag        Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.
      * @param observableTag Used to identify transformed observable.
      * @return Transformer adding logging onNext/onError/onCompleted events to observable.
      */
@@ -122,12 +122,11 @@ public class LogTransformer {
     }
 
     /**
-     *
-     * @param logTag Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.
+     * @param logTag        Used to identify the source of a log message. It usually identifies the class or activity where the log call occurs.
      * @param observableTag Used to identify transformed observable.
-     * @param logger Logger instance used to print messages.
-     * @see Logger
+     * @param logger        Logger instance used to print messages.
      * @return Transformer adding logging onNext/onError/onCompleted events to observable.
+     * @see Logger
      */
     @Nonnull
     public static <T> Observable.Transformer<T, T> transformer(@Nonnull final String logTag,

--- a/rx-android-extensions/src/test/java/com/appunite/rx/android/util/LogTransformerTest.java
+++ b/rx-android-extensions/src/test/java/com/appunite/rx/android/util/LogTransformerTest.java
@@ -6,6 +6,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import rx.Observable;
+import rx.Subscription;
 import rx.functions.Action1;
 
 import static org.mockito.Matchers.anyString;
@@ -21,6 +22,18 @@ public class LogTransformerTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testSubscribeAndUnsubscribe() throws Exception {
+        final Subscription subscription = Observable.just(1)
+                .compose(LogTransformer.transformer("tag", "test", logger))
+                .subscribe();
+
+        subscription.unsubscribe();
+
+        verify(logger).logSubscribe(matches("tag"), anyString());
+        verify(logger).logUnsubscribe(matches("tag"), anyString());
     }
 
     @Test


### PR DESCRIPTION
Log transformer will now log five methods (onNext, onCompleted, onError, onSubscribe and onUnsubscribe) instead of three.
