### PR TITLE
Explicitly set compile and target version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ dependencies {
     compile 'com.github.jacek-marchwicki.rx-java-extensions:rx-android-extensions:master-SNAPSHOT'
 
     // or use specific version
-    compile 'com.github.jacek-marchwicki.rx-java-extensions:rx-extensions:1.0.1'
-    compile 'com.github.jacek-marchwicki.rx-java-extensions:rx-android-extensions:1.0.1'
+    compile 'com.github.jacek-marchwicki.rx-java-extensions:rx-extensions:1.0.2'
+    compile 'com.github.jacek-marchwicki.rx-java-extensions:rx-android-extensions:1.0.2'
 }
 ```
 

--- a/example-model/build.gradle
+++ b/example-model/build.gradle
@@ -6,6 +6,8 @@ buildscript {
 }
 
 apply plugin: 'java'
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 repositories {
     mavenCentral()

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -98,4 +98,9 @@ android {
         htmlOutput file("${reportsDir}/lint/lint-results.html")
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
+    }
+
 }

--- a/rx-android-extensions/build.gradle
+++ b/rx-android-extensions/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 group='com.github.jacek-marchwicki.rx-java-extensions'
 // When changing update README file
-version='1.0.1'
+version='1.0.2'
 
 repositories {
     mavenCentral()
@@ -55,4 +55,8 @@ android {
         exclude 'LICENSE.txt'
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
+    }
 }

--- a/rx-extensions/build.gradle
+++ b/rx-extensions/build.gradle
@@ -9,7 +9,9 @@ apply plugin: 'maven'
 
 group='com.github.jacek-marchwicki.rx-java-extensions'
 // When changing update README file
-version='1.0.1'
+version='1.0.2'
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
- Explicitly set source and target compatibility to `1.7`. Without it you can encounter on Android

```
UNEXPECTED TOP-LEVEL EXCEPTION: com.android.dx.cf.iface.ParseException: bad class file magic (cafebabe) or version (0034.0000)
```
- Bump version to `1.0.2`
